### PR TITLE
Added option to select license type

### DIFF
--- a/emf4cpp.tests/EndUserLicense/enduserlicense.ecore
+++ b/emf4cpp.tests/EndUserLicense/enduserlicense.ecore
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ecore:EPackage xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:ecore="http://www.eclipse.org/emf/2002/Ecore"
+    name="enduserlicense" nsURI="http:///com.example.enduserlicense.ecore"
+    nsPrefix="enduserlicense"/>

--- a/emf4cpp.tests/update-examples.sh
+++ b/emf4cpp.tests/update-examples.sh
@@ -14,11 +14,43 @@ FILES="./tree-bintree/Tree.ecore
 "
 
 EMF4CPP=../../emf4cpp
-EMF4CPPJAR=`pwd`/../org.csu.emf4cpp.generator/org.csu.emf4cpp.generator_1.0.0.jar
+EMF4CPPJAR=`pwd`/../org.csu.emf4cpp.generator/org.csu.emf4cpp.generator_1.1.0.jar
 GENERATOR="java -jar $EMF4CPPJAR"
 
+
+function testLicenseText ()
+{
+	DIR=`dirname $1`
+	FILES="$DIR/CMakeLists.txt $DIR/*.hpp $DIR/*.cpp"
+	rm -f $FILES
+
+	(cd $DIR ; $GENERATOR -o . -e $EMF4CPP `basename $1`)
+	egrep -L "was created by EMF4CPP [[:digit:]]+.[[:digit:]]+.[[:digit:]]+ and is copyrighted by the" $FILES
+	if [ $? -ne 0 ] ; then
+	    echo "License text failed: No foreign copyright when called w/o -i"
+	    return 1
+	fi
+
+	rm -f $FILES
+
+	(cd $DIR ; $GENERATOR --internal -o . -e $EMF4CPP `basename $1`)
+	grep -L "Copyright (C) Cátedra SAES-UMU 2010 <andres.senac@um.es>" $FILES
+	if [ $? -ne 0 ] ; then
+	    echo "License text failed: No internal copyright when called w/ -i"
+	    return 2
+	fi
+
+	echo "License text passed for $1"
+	return 0
+}
+
+
 if test -n "$1" ; then
-	(cd `dirname $1` ; $GENERATOR -o . -e $EMF4CPP `basename $1`)
+	if test "$1" == "EndUserLicense/enduserlicense.ecore" ; then
+		testLicenseText "EndUserLicense/enduserlicense.ecore"
+	else
+		(cd `dirname $1` ; $GENERATOR -o . -e $EMF4CPP `basename $1`)
+	fi
 else
   	for i in $FILES; do
 
@@ -31,4 +63,6 @@ else
 
 		echo "Done!"
 	done
+
+	testLicenseText "EndUserLicense/enduserlicense.ecore"
 fi

--- a/org.csu.emf4cpp.generator/META-INF/MANIFEST.MF
+++ b/org.csu.emf4cpp.generator/META-INF/MANIFEST.MF
@@ -2,7 +2,7 @@ Manifest-Version: 1.0
 Bundle-ManifestVersion: 2
 Bundle-Name: org.csu.emf4cpp.generator
 Bundle-SymbolicName: org.csu.emf4cpp.generator; singleton:=true
-Bundle-Version: 0.0.2
+Bundle-Version: 1.1.0
 Require-Bundle: org.eclipse.jdt.core;bundle-version="3.5.0",
  org.eclipse.xtend.profiler;resolution:=optional,
  org.apache.commons.logging,

--- a/org.csu.emf4cpp.generator/emf4cpp.generator.sh
+++ b/org.csu.emf4cpp.generator/emf4cpp.generator.sh
@@ -26,5 +26,5 @@ ECORECPP_PATH="${GENERATOR_DIR}/../include/emf4cpp"
 
 
 # Go go go
-JAR="${BASEDIR}/org.csu.emf4cpp.generator_1.0.0.jar"
+JAR="${BASEDIR}/org.csu.emf4cpp.generator_1.1.0.jar"
 java -jar ${JAR} -e ${ECORECPP_PATH} -o ${DEST_DIR} $@

--- a/org.csu.emf4cpp.generator/src/org/csu/emf4cpp/generator/Generator.java
+++ b/org.csu.emf4cpp.generator/src/org/csu/emf4cpp/generator/Generator.java
@@ -28,9 +28,11 @@ import org.eclipse.xtend.expression.Variable;
 import org.eclipse.xtend.typesystem.emf.EmfRegistryMetaModel;
 
 public class Generator {
+	private static String version = "1.1.0";
     private static String templatePath = "template::Main::main";
 
-    public void generate(URI fileURI, String targetDir, String prSrcPaths, String ecPath) {
+    public void generate(URI fileURI, String targetDir, String prSrcPaths, String ecPath,
+			boolean internalLicense) {
 
         ResourceSet rs = new ResourceSetImpl();
         rs.getResourceFactoryRegistry().getExtensionToFactoryMap().put("ecore",
@@ -41,6 +43,8 @@ public class Generator {
         Map<String, Variable> globalVarsMap = new HashMap<String, Variable>();
         globalVarsMap.put("ecorePath", new Variable("ecorePath", ecPath));
         globalVarsMap.put("ecoreCppPath", new Variable("ecoreCppPath", ecPath));
+        globalVarsMap.put("emf4cppVersion", new Variable("emf4cppVersion", version));
+        globalVarsMap.put("internalLicense", new Variable("internalLicense", internalLicense));
 
         // Configure outlets
         CppBeautifier cppBeautifier = new CppBeautifier();
@@ -98,6 +102,15 @@ public class Generator {
             System.exit(1);
         }
 
+        if (cmd.hasOption("V")) {
+			System.out.println("emf4cpp " + version);
+			System.out.println("Copyright (C) Cátedra SAES-UMU 2010 <andres.senac@um.es>");
+			System.out.println("License LGPLv3+: GNU LGPL version 3 or later <http://gnu.org/licenses/lgpl.html>.");
+			System.out.println("EMF4CPP is free software: you can redistribute it and/or modify it.");
+			System.out.println("There is NO WARRANTY, to the extent permitted by law.");
+			System.exit(0);
+        }
+
         if (cmd.hasOption("h")) {
             System.out.println("Options:");
             for (Option opt : (Collection<Option>) options.getOptions()) {
@@ -134,7 +147,8 @@ public class Generator {
             System.exit(1);
         }
 
-        new Generator().generate(URI.createFileURI(filePath), targetDir, prSrcPaths, ecPath);
+        new Generator().generate(URI.createFileURI(filePath), targetDir, prSrcPaths, ecPath,
+				cmd.hasOption("i"));
     }
 
     private final static Options options = new Options(); // Command line
@@ -149,10 +163,14 @@ public class Generator {
         options.addOption("v", false, "Verbose.");
 
         options.addOption("o", true,
-                        "Output directory for the generated files. Default is current directory.");
+			  "Output directory for the generated files. Default is current directory.");
         options.addOption("p", true,
-                "Protected regions directories. Default is output directory.");
+			  "Protected regions directories. Default is output directory.");
         options.addOption("e", true,
-        "EMF4CPP path.");
+			  "EMF4CPP path.");
+        options.addOption("V", "version", false,
+			  "Display version information and exit.");
+        options.addOption("i", "internal", false,
+			  "Add EMF4CPP license instead of more permissive end-user license.");
     }
 }

--- a/org.csu.emf4cpp.generator/src/template/CMakeLists.xpt
+++ b/org.csu.emf4cpp.generator/src/template/CMakeLists.xpt
@@ -22,7 +22,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 «DEFINE MainCMake FOR EPackage»
 «FILE "CMakeLists.txt" NOOVERWRITE-»
+«IF GLOBALVAR internalLicense»
 «EXPAND template::License::LicenseMakefile FOR "CMakeLists.txt"-»
+«ELSE»
+«EXPAND template::EndUserLicense::LicenseMakefile FOR "CMakeLists.txt"-»
+«ENDIF»
 cmake_minimum_required(VERSION 2.6)
 
 project(emf4cpp-«name» CXX)
@@ -51,7 +55,11 @@ include(CPack)
 «DEFINE CMake FOR EPackage»
 «LET getFQN("_") AS fqn»
 «FILE fqn+".cmake"-»
+«IF GLOBALVAR internalLicense»
 «EXPAND template::License::LicenseMakefile FOR fqn+".cmake"-»
+«ELSE»
+«EXPAND template::EndUserLicense::LicenseMakefile FOR fqn+".cmake"-»
+«ENDIF»
 set(CMAKE_CXX_FLAGS "")
 set(CMAKE_CXX_FLAGS_DEBUG "-Wall -g -DDEBUG")
 set(CMAKE_CXX_FLAGS_RELEASE "-Wall -O3 -funroll-loops")

--- a/org.csu.emf4cpp.generator/src/template/EClassCPP.xpt
+++ b/org.csu.emf4cpp.generator/src/template/EClassCPP.xpt
@@ -29,7 +29,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 «DEFINE cpp FOR EClass»
 «FILE getFQN("/")+".cpp"-»
+«IF GLOBALVAR internalLicense»
 «EXPAND template::License::License FOR getFQN("/")+".cpp"-»
+«ELSE»
+«EXPAND template::EndUserLicense::License FOR getFQN("/")+".cpp"-»
+«ENDIF»
 #include "«name».hpp"
 «FOREACH getAllIncludeFiles() AS include-»
 #include <«include».hpp>

--- a/org.csu.emf4cpp.generator/src/template/EClassHPP.xpt
+++ b/org.csu.emf4cpp.generator/src/template/EClassHPP.xpt
@@ -27,7 +27,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 «DEFINE hpp FOR EClass»
 «FILE getFQN("/")+".hpp"-»
+«IF GLOBALVAR internalLicense»
 «EXPAND template::License::License FOR getFQN("/")+".hpp"-»
+«ELSE»
+«EXPAND template::EndUserLicense::License FOR getFQN("/")+".hpp"-»
+«ENDIF»
 #ifndef «getHeaderDef()»_HPP
 #define «getHeaderDef()»_HPP
 

--- a/org.csu.emf4cpp.generator/src/template/EClassImplCPP.xpt
+++ b/org.csu.emf4cpp.generator/src/template/EClassImplCPP.xpt
@@ -31,7 +31,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 «DEFINE cpp FOR EClass»
 «FILE getFQN("/")+"Impl.cpp"-»
+«IF GLOBALVAR internalLicense»
 «EXPAND template::License::License FOR getFQN("/")+"Impl.cpp"-»
+«ELSE»
+«EXPAND template::EndUserLicense::License FOR getFQN("/")+"Impl.cpp"-»
+«ENDIF»
 #include "«name».hpp"
 #include <«EPackage.getPackagePrefix()».hpp>
 «FOREACH getAllIncludeFiles() AS include-»

--- a/org.csu.emf4cpp.generator/src/template/EPackageCPP.xpt
+++ b/org.csu.emf4cpp.generator/src/template/EPackageCPP.xpt
@@ -23,7 +23,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 «DEFINE cpp FOR EPackage»
 «FILE getFQN("/")+".cpp"-»
+«IF GLOBALVAR internalLicense»
 «EXPAND template::License::License FOR getFQN("/")+".cpp"-»
+«ELSE»
+«EXPAND template::EndUserLicense::License FOR getFQN("/")+".cpp"-»
+«ENDIF»
 #include "«name».hpp"
 
 «ENDFILE»

--- a/org.csu.emf4cpp.generator/src/template/EPackageHPP.xpt
+++ b/org.csu.emf4cpp.generator/src/template/EPackageHPP.xpt
@@ -23,7 +23,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 «DEFINE hpp FOR EPackage»
 «FILE getFQN("/")+".hpp"-»
+«IF GLOBALVAR internalLicense»
 «EXPAND template::License::License FOR getFQN("/")+".hpp"-»
+«ELSE»
+«EXPAND template::EndUserLicense::License FOR getFQN("/")+".hpp"-»
+«ENDIF»
 #ifndef «getHeaderDef()»_HPP
 #define «getHeaderDef()»_HPP
 
@@ -59,7 +63,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 «ENDFILE»
 
 «FILE getFQN("/")+"_forward.hpp"-»
+«IF GLOBALVAR internalLicense»
 «EXPAND template::License::License FOR getFQN("/")+"_forward.hpp"-»
+«ELSE»
+«EXPAND template::EndUserLicense::License FOR getFQN("/")+"_forward.hpp"-»
+«ENDIF»
 #ifndef _«getHeaderDef()»_FORWARD_HPP
 #define _«getHeaderDef()»_FORWARD_HPP
 

--- a/org.csu.emf4cpp.generator/src/template/Factory.xpt
+++ b/org.csu.emf4cpp.generator/src/template/Factory.xpt
@@ -23,7 +23,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 «DEFINE hppcpp FOR EPackage»
 «FILE getFactoryPrefix()+".hpp"-»
+«IF GLOBALVAR internalLicense»
 «EXPAND template::License::License FOR getFactoryPrefix()+".hpp"-»
+«ELSE»
+«EXPAND template::EndUserLicense::License FOR getFactoryPrefix()+".hpp"-»
+«ENDIF»
 #ifndef _«getHeaderDef()»FACTORY_HPP
 #define _«getHeaderDef()»FACTORY_HPP
 
@@ -61,7 +65,11 @@ protected:
 «ENDFILE»
 
 «FILE getFactoryPrefix()+".cpp"-»
+«IF GLOBALVAR internalLicense»
 «EXPAND template::License::License FOR getFactoryPrefix()+".cpp"-»
+«ELSE»
+«EXPAND template::EndUserLicense::License FOR getFactoryPrefix()+".cpp"-»
+«ENDIF»
 #include <«getFactoryPrefix()».hpp>
 
 using namespace ::«getFQN()»;

--- a/org.csu.emf4cpp.generator/src/template/FactoryImpl.xpt
+++ b/org.csu.emf4cpp.generator/src/template/FactoryImpl.xpt
@@ -24,7 +24,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 «DEFINE hppcpp FOR EPackage»
 «FILE getFactoryPrefix()+"Impl.cpp"-»
+«IF GLOBALVAR internalLicense»
 «EXPAND template::License::License FOR getFactoryPrefix()+"Impl.cpp"-»
+«ELSE»
+«EXPAND template::EndUserLicense::License FOR getFactoryPrefix()+"Impl.cpp"-»
+«ENDIF»
 #include <«getFactoryPrefix()».hpp>
 #include <«getPackagePrefix()».hpp>
 «FOREACH EClassifiers.typeSelect(EClass) AS class-»

--- a/org.csu.emf4cpp.generator/src/template/Makefile.xpt
+++ b/org.csu.emf4cpp.generator/src/template/Makefile.xpt
@@ -22,7 +22,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 «DEFINE Makefile FOR EPackage»
 «FILE "Makefile."+getFQN("_")-»
+«IF GLOBALVAR internalLicense»
 «EXPAND template::License::LicenseMakefile FOR "Makefile."+getFQN("_")-»
+«ELSE»
+«EXPAND template::EndUserLicense::LicenseMakefile FOR "Makefile."+getFQN("_")-»
+«ENDIF»
 
 «getFQN("_").toUpperCase()»__OBJS=«getFQN("/")».o \
     «getFQN("/")»/«name.toFirstUpper()»Factory.o \
@@ -45,7 +49,11 @@ $(«getFQN("_").toUpperCase()»__LIB): $(«getFQN("_").toUpperCase()»__OBJS)
 
 «DEFINE MainMakefile FOR EPackage»
 «FILE "Makefile" NOOVERWRITE»
+«IF GLOBALVAR internalLicense»
 «EXPAND template::License::LicenseMakefile FOR "Makefile"-»
+«ELSE»
+«EXPAND template::EndUserLicense::LicenseMakefile FOR "Makefile"-»
+«ENDIF»
 LIBS=
 OBJS=
 

--- a/org.csu.emf4cpp.generator/src/template/Package.xpt
+++ b/org.csu.emf4cpp.generator/src/template/Package.xpt
@@ -26,7 +26,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 «DEFINE hppcpp FOR EPackage»
 «FILE getPackagePrefix()+".hpp"-»
+«IF GLOBALVAR internalLicense»
 «EXPAND template::License::License FOR getPackagePrefix()+".hpp"-»
+«ELSE»
+«EXPAND template::EndUserLicense::License FOR getPackagePrefix()+".hpp"-»
+«ENDIF»
 #ifndef _«getHeaderDef()»PACKAGE_HPP
 #define _«getHeaderDef()»PACKAGE_HPP
 
@@ -105,7 +109,11 @@ protected:
 «ENDFILE»
 
 «FILE getPackagePrefix()+".cpp"-»
+«IF GLOBALVAR internalLicense»
 «EXPAND template::License::License FOR getPackagePrefix()+".cpp"-»
+«ELSE»
+«EXPAND template::EndUserLicense::License FOR getPackagePrefix()+".cpp"-»
+«ENDIF»
 #include <«getPackagePrefix()».hpp>
 
 using namespace ::«getFQN()»;

--- a/org.csu.emf4cpp.generator/src/template/PackageImpl.xpt
+++ b/org.csu.emf4cpp.generator/src/template/PackageImpl.xpt
@@ -27,7 +27,11 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 «DEFINE hppcpp FOR EPackage»
 «FILE getPackagePrefix()+"Impl.cpp"-»
+«IF GLOBALVAR internalLicense»
 «EXPAND template::License::License FOR getPackagePrefix()+"Impl.cpp"-»
+«ELSE»
+«EXPAND template::EndUserLicense::License FOR getPackagePrefix()+"Impl.cpp"-»
+«ENDIF»
 #include <«getPackagePrefix()».hpp>
 #include <«getFactoryPrefix()».hpp>
 #include <ecore.hpp>


### PR DESCRIPTION
- By default all files generated by emf4cpp have been tagged as "copyright by
  Cátedra SAES-UMU" and licensed under LGPLv3+. As this was not intended by
  the original authors, a command line option -i / --internal has been added.
- When this option is used, the license is still the same as before. This can
  be used during the generation process of emf4cpp itself.
- Otherwise, i.e. when the option is not used, the license text from
  template/EndUserLicense.xpt is used. It mentions the usage of emf4cpp and
  references the github repository, but otherwise does not claim
  copyrights. Instead this is left to the user or the owner of the ecore
  model.
- emf4cpp.tests/update-examples.sh was extended by a minimal model,
  EndUserLicense/enduserlicense.ecore, to check the creation of the two
  different license texts. Usage:
    cd emf4cpp.tests
    ./update-examples.sh EndUserLicense/enduserlicense.ecore
- Additionally a command line option -V / --version was introduced. When used,
  the version information is emitted (in a form inspired by GNU grep), and the
  program exits.
- Following the Semantic Versioning model http://semver.org/, the version
  information was increased to 1.1.0 (introduction of backwards compatible
  functionality). The version number is configured in Generator.version.

Change-Id: I2f3d4fcff5ff8225d6fddc3eb963ea1175c1541e
