### PR TITLE
Fixes for issues introduced by merged pull request #5

### DIFF
--- a/org.csu.emf4cpp.generator/src/template/EClassImplCPP.xpt
+++ b/org.csu.emf4cpp.generator/src/template/EClassImplCPP.xpt
@@ -107,7 +107,7 @@ void «name»::_initialize()
     ::ecore::EJavaObject _any;
     switch (_featureID)
     {
-    «FOREACH EStructuralFeatures.select(e|!e.derived) AS ef-»
+    «FOREACH EAllStructuralFeatures.select(e|!e.derived) AS ef-»
         case «ef.getCPPFQN()»:
             {
                 «IF EReference.isInstance(ef)-»
@@ -137,7 +137,7 @@ void «name»::eSet ( ::ecore::EInt _featureID, ::ecore::EJavaObject const& _new
 {
     switch (_featureID)
     {
-    «FOREACH EStructuralFeatures.select(e|!e.derived) AS ef-»
+    «FOREACH EAllStructuralFeatures.select(e|!e.derived) AS ef-»
         case «ef.getCPPFQN()» :
             {
                 «IF EReference.isInstance(ef)-»
@@ -170,7 +170,7 @@ void «name»::eSet ( ::ecore::EInt _featureID, ::ecore::EJavaObject const& _new
 {
     switch (_featureID)
     {
-    «FOREACH EStructuralFeatures.select(e|e.EType.ETypeParameters.isEmpty) AS ef-»
+    «FOREACH EAllStructuralFeatures.select(e|e.EType.ETypeParameters.isEmpty) AS ef-»
         case «ef.getCPPFQN()» :
             «IF EReference.isInstance(ef)-»
                 «IF ef.upperBound == 1-»
@@ -202,7 +202,7 @@ void «name»::eUnset ( ::ecore::EInt _featureID)
 {
     switch (_featureID)
     {
-    «FOREACH EStructuralFeatures.select(e|e.unsettable) AS ef-»
+    «FOREACH EAllStructuralFeatures.select(e|e.unsettable) AS ef-»
        «REM»
         case «ef.getCPPFQN()» :
             «IF EClass.isInstance(ef.EType)-»

--- a/org.csu.emf4cpp.generator/src/template/PackageImpl.xpt
+++ b/org.csu.emf4cpp.generator/src/template/PackageImpl.xpt
@@ -48,7 +48,7 @@ along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #include <ecore/ETypeParameter.hpp>
 «LET getExternalTypes() AS types-»
     «FOREACH types.EPackage.toSet() AS pkg-»
-#include <«getFQN2(pkg,"/")»/«pkg.getPackageName()».hpp>
+#include <«pkg.getFQN("/")»/«pkg.getPackageName()».hpp>
     «ENDFOREACH-»
     «FOREACH types.typeSelect(EClass) AS e-»
 #include <«e.getFQN("/")».hpp>


### PR DESCRIPTION
PackageImpl.xpt:
The undefined function FQN2() was replaced by the
function used before.

EClassImplCPP.xpt:
All features (also of the base classes) must appear
in the switch constructs of the eGet/eSet methods since
no call to the superclass takes place. Therefore we have
to loop over 'EAllStructuralFeatures' of the class.

Change-Id: I84a0abb52c84aa9addfab61ca61ca2509f99a0e6