### PR TITLE
The Simple Emf4cpp Parser does not Resolve References

### DIFF
--- a/emf4cpp.tests/company/test/test.cpp
+++ b/emf4cpp.tests/company/test/test.cpp
@@ -67,7 +67,11 @@ int main(int argc, char* argv[])
     EObject_ptr eobj = _dser.load ("UMU.xmi");
 
     {
-		boost::intrusive_ptr<Company> umu (::ecore::as< Company >(eobj));
+		Company_ptr umu (::ecore::as< Company >(eobj));
+		const auto& departments = umu->getDepartments();
+		auto manager = departments[0]->getManager();
+		if (!manager)
+			std::cerr << "No reference to manager!" << std::endl;
     }
 }
 

--- a/emf4cpp/ecorecpp/parser/handler.cpp
+++ b/emf4cpp/ecorecpp/parser/handler.cpp
@@ -318,7 +318,9 @@ void handler::resolveReferences()
 
             ref_parser::SemanticState ss;
             State< ref_parser::SemanticState > st(ss, s, size);
-            assert(ref_parser::grammar::references::match(st));
+            bool parsingSuccessful = ref_parser::grammar::references::match(st);
+            assert(parsingSuccessful);
+            (void)parsingSuccessful;
 
             ref_parser::references_t& _references = ss.get_references();
 


### PR DESCRIPTION
The parsing call was moved out of the assert statement so that
it also gets executed in release builds.

A test for working reference resolving was added to the
emf4cpp.tests/company example.

Change-Id: I6f67ea81358737d4406a44b968a843223613043c
(cherry picked from commit 76d49f17a1a661805d3e7f5e4e2f696cc0e8114f)